### PR TITLE
bestFitLine.hideWithParents only works on 0th graph

### DIFF
--- a/bestFitLine/bestFitLine.js
+++ b/bestFitLine/bestFitLine.js
@@ -156,7 +156,7 @@ AmCharts.bestFitLineProcess = function( chart, validateData ) {
 
 							// anything changed?
 							if ( graph.hidden === graph.hiddenBefore )
-								return;
+								continue;
 
 							// set current setting
 							graph.hiddenBefore = graph.hidden;


### PR DESCRIPTION
The callback registered on the chart redraw called "drawn" is responsible for looping through the graphsWithTrendLines and keeping the visibility ("hidden") of the bestFitLine in sync with the parent graph. 

However since the "anything changed?" check does a full on return rather than a continue, it fails to check the remaining graphs.
And since the listener is only registered on the first registration of the bestFitLine, we are left with 1 listener which only works on the 1st graph.

The fix appears to be simple in changing the return to a continue.