### PR TITLE
Added optional valueField config setting when wanting to use another …

### DIFF
--- a/bestFitLine/README.md
+++ b/bestFitLine/README.md
@@ -100,6 +100,15 @@ Add `extend: true` to your `bestFitLine` config, and the plugin will extend the
 trend line to fit the whole scope of data, even if your actual graph starts and 
 ends at some mid-point in data.
 
+### Using another valueField from dataProvidor
+
+Add `valueField: "theField"` to your `bestFitLine` config to change the field 
+used to calculate the trend line.
+Default is the current graph's valueField.
+
+Can be useful when using "openField" setting in graph (bar charts that doesn't
+start at 0).
+
 
 ## Examples
 

--- a/bestFitLine/bestFitLine.js
+++ b/bestFitLine/bestFitLine.js
@@ -41,18 +41,25 @@ AmCharts.bestFitLineProcess = function( chart, validateData ) {
 			lastCat,
 			firstDataCat,
 			lastDataCat;
+
 		if ( graph.bestFitLine !== undefined ) {
 			// found a graph
 			// generate values
 			var x = [],
 				y = [];
+
+			// set valueField setting
+			if ( graph.bestFitLine.valueField === undefined ) {
+				graph.bestFitLine.valueField = graph.valueField;
+			}
+
 			for ( var z = 0; z < chart.dataProvider.length; z++ ) {
 
 				// calculate category
 				var cat = getCategoryIndex( chart.dataProvider[ z ][ chart.categoryField ], z, chart );
 
 				// get value
-				var value = chart.dataProvider[ z ][ graph.valueField ] ;
+				var value = chart.dataProvider[ z ][ graph.bestFitLine.valueField ] ;
 
 				if ( value != null ) {
 					value = +value;
@@ -123,7 +130,7 @@ AmCharts.bestFitLineProcess = function( chart, validateData ) {
 
 			// create a graph for the best fit line
 			var trendGraph = graph.bestFitLine;
-			trendGraph.valueField = graph.valueField + "FitLine";
+			trendGraph.valueField = graph.bestFitLine.valueField + "FitLine";
 			if ( trendGraph.trendInited !== true )
 				chart.graphs.push( trendGraph );
 			trendGraph.trendInited = true;


### PR DESCRIPTION
…valuefield than graph.valueField.

When using "openField" together with "valueField" bestFitLine doesn't take the total range in to account. Only the valueField.

By adding graph.bestFitLine.valueField config, it is possible to change the column from the dataprovider that the trend line is calculated from and thereby using a calculated total value instead of the maximum value.

I have not minified the file.